### PR TITLE
SMatrix

### DIFF
--- a/nstts/SquareMatrix/src/Matrix.hpp
+++ b/nstts/SquareMatrix/src/Matrix.hpp
@@ -1,3 +1,10 @@
 #pragma once
+
+/** RE:
+ * try to import this header into tests and see what will happen
+ * Then explain behaviour and fix 
+ * Note: It is okay to put whole definition of class into header
+ * there is pros and cons of such desicion
+ */
 class VectorMatrix;
 class Smatrix;


### PR DESCRIPTION
### Summary

Your code contains several cases of UB, some of them detected by sanitizers.
There is some ordinary cases of UB that was discussed on lectures, some of them not

So let's see all of them:

#### Order of evaluation, side effects and so on
Firstly lets see following code
```cc
for (int i = 0; i < size_; data_[i][i] = d[i++])
```
According the semantic of your program this code should put elements of flat array `d` 
on the diagonal of the 2D square matrix `data_`

Let's evaluate this loop precisely, keeping in mind that in expressions `A = B` expression `B` is evaluated before `A`
(standard says so™)

`i == 0` when we firstly try to evaluate `data_[i][i] = d[i++]`. Evaluation:
1. `data_[i][i] = d[-> i++]`: `i++` can be thought as reading `i` then increment `i` in the _some time_ before `B` is evaluated completely. 
2. `data_[i][i] = ->d[0]`: then we value of `d[0]`
3.  `->data_[i][i] = (value from d[0])`: At this point `i == 1` (standard says so™)
4. `data_[->i][i] = (value from d[0])`: remember that `i==1`
5. `(->data_[1])[i] = (value from d[0])`
6. `(the 2nd pointer in data)[->i] = (value from d[0])`
7. `(then 2nd pointer in data)[1] = (value from d[0])`
8. So evaluated expression is the same as `data_[1][1] = d[0]`
If we trying to access the last element of `data_` this is UB

#### Going wild
Previous cycle will lead to access memory out of bound every time when we try to evaluate this cycle, after that it is UB.
But the result of this expression is undefined itself: `data_[i][k] * other.data_[k++][j]`.

The reason of this is that in expressions like `A * B` the order of evaluation of it's operands is unspecified (standard says so™)
So depending of order of evaluation the expressions `data_[i][k]` and `other.data_[k++][j]` results can be different (or you can access memory out of bounds of data_ for example). This happens because of side effect of `k++` (changing value of `k`).

#### How to fix
So the general answer is be more explicit.

Don't use third expression of `for` statement for anything except incrementing loop counter.
Often we use `for` loops instead of `while` because it collects all control elements of the cycle in one place, therefore
it is harder to make a mistake. Don't break up this, be clear even if it takes more lines of code

Don't use pre- or post-increment in compound expressions if there is more than one use of incremented/decremented value in the expression. So it is okay to write `arr[i++]` or `data[j] = arr[i++]` is okay, even `arr[i++] = i` has defined behavior, but something more complicated maybe has an error inside. Don't use something if you don't confident in it's behavior.

If you want to learn the spell "standard says so™" in case of order of evaluation then use [cppreference](https://en.cppreference.com/w/cpp/language/eval_order).

### Move assignment operator

```
  Smatrix& operator=(Smatrix&& other) noexcept {
    if (this != &other) {
      data_ = other.data_;
      size_ = other.size_;
    }
    return *this;
  }
```
When you write something with move semantic you should always think that `other` will be deleted immediately 
after the end of operator or ctor. This will help you avoid making some mistakes.

The first thing you need to think about is how to steal a dead man's data. The data should be stolen completely.
A dead man should not take data with him to the grave. In your case it is, when other will be deleted it will delete it's data.
So the next every operation with `this` object is UB, because `data_` will be deleted. 

But we are civilized people after all, so secondly we need to make sure that the dead man dies well.
To do this we need to make sure that we leave it in a consistent, but not necessarily predictable, state. Leaving an object in a consistent state means preserving its invariants. For example, you can _nullify_ the dead man

```
  Smatrix& operator=(Smatrix&& other) noexcept {
    if (this != &other) {
      data_ = other.data_;
      size_ = other.size_;
      delete[] data_; // don't forget about memory leaks
      other.data_ = null;
      other.size_ = 0; // We need to preserve invariants so that the destructor can delete the object correctly.
    }
    return *this;
  }
```
Or we can assume that the `this` keeps it's invariants. So we can give our current state to the dead man, it's dstr will
deal with our data well.

```
  Smatrix& operator=(Smatrix&& other) noexcept {
    if (this != &other) {
      std::swap(data_, other.data_);
      std::swap(size_, other.size_);
    }
    return *this;
  }
```


